### PR TITLE
Fix GitHub Pages baseURL for proper asset loading

### DIFF
--- a/professor/course.yml
+++ b/professor/course.yml
@@ -24,7 +24,7 @@ contact_policy: "Email within 24 hours for questions."
 site:
   title: "Class Template Framework"
   description: "A foundational template for educational repositories"
-  baseurl: ""
+  baseurl: "https://sonder-art.github.io/class_template/"
 
 # Future extensibility - components read this automatically
 branding:

--- a/professor/hugo.toml
+++ b/professor/hugo.toml
@@ -3,7 +3,7 @@
 # Variables are filled from course.yml and config.yml ONLY
 # NO dependency on root dna.yml for rendering
 
-baseURL = ""
+baseURL = "https://sonder-art.github.io/class_template/"
 languageCode = "en-us"
 title = "Class Template Framework"
 


### PR DESCRIPTION
- Set baseURL to https://sonder-art.github.io/class_template/
- Regenerated hugo.toml with correct paths
- Fixes styling and asset loading issues on GitHub Pages