### PR TITLE
Fix GitHub Pages 404s with custom domain and production build

### DIFF
--- a/professor/course.yml
+++ b/professor/course.yml
@@ -24,7 +24,7 @@ contact_policy: "Email within 24 hours for questions."
 site:
   title: "Class Template Framework"
   description: "A foundational template for educational repositories"
-  baseurl: "https://sonder-art.github.io/class_template/"
+  baseurl: "https://www.sonder.art/class_template/"
 
 # Future extensibility - components read this automatically
 branding:

--- a/professor/framework_code/scripts/manage_modules/operation_sequencer.py
+++ b/professor/framework_code/scripts/manage_modules/operation_sequencer.py
@@ -197,7 +197,8 @@ class OperationSequencer:
             command=[
                 "hugo",
                 "--destination", str(output_dir),
-                "--config", "hugo.toml"
+                "--config", "hugo.toml",
+                "--environment", "production"
             ],
             description="Building static site with Hugo",
             working_directory=self.current_dir,

--- a/professor/hugo.toml
+++ b/professor/hugo.toml
@@ -3,7 +3,7 @@
 # Variables are filled from course.yml and config.yml ONLY
 # NO dependency on root dna.yml for rendering
 
-baseURL = "https://sonder-art.github.io/class_template/"
+baseURL = "https://www.sonder.art/class_template/"
 languageCode = "en-us"
 title = "Class Template Framework"
 


### PR DESCRIPTION
🔧 FIXES:
- Set baseURL to https://www.sonder.art/class_template/ (custom domain)
- Add --environment production to Hugo build (removes livereload.js)
- Regenerated hugo.toml with correct paths

✅ RESULT:
- Homepage and all sub-pages will load correctly
- No more 404 errors on navigation
- Proper asset loading with custom domain